### PR TITLE
Fix bug

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -91,7 +91,7 @@ class ContentIndex_Plugin implements Typecho_Plugin_Interface
 			$curlevel = 0;
 			foreach ($index as $i) {
 				if ($i["level"]>$curlevel) $index_out.="<ul>\n";
-				elseif ($i["level"]<$curlevel) $index_out.="</ul>\n";
+				elseif ($i["level"]<$curlevel) $index_out.=str_repeat("</ul>\n", $curlevel-$i["level"]);
 				$curlevel = $i["level"];
 				$index_out .= "<li>{$i['link']}</li>\n";
 			}


### PR DESCRIPTION
If the content is like this, for example:
```
<h1>AAAAA</h1>
  <h2>BBBBB</h2>
      <h3>CCCCC</h3>
  <h2>BBBBB</h2>
      <h3>CCCCC</h3>
      <h3>CCCCC</h3>
<h1>AAAAA</h1>
```

It seems that more than one `'</ul>\n'` is needed.